### PR TITLE
Add Claude Code GitHub workflow (Bedrock)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+# Lets you invoke Claude from any issue or PR by mentioning @claude.
+# Runs on AWS Bedrock — auth comes from the AWS_BEARER_TOKEN_BEDROCK repo
+# secret (a long-term Bedrock API key), never committed to the repo.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only run when someone actually mentions @claude.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Route the underlying Claude Code CLI through AWS Bedrock.
+          CLAUDE_CODE_USE_BEDROCK: "1"
+          AWS_REGION: us-east-1
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+        with:
+          use_bedrock: "true"
+          claude_args: |
+            --model us.anthropic.claude-opus-4-8


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` so mentioning `@claude` in issues and pull requests invokes Claude Code.

## Auth
Runs on **AWS Bedrock** (region `us-east-1`, model `us.anthropic.claude-opus-4-8`). Credentials come from the `AWS_BEARER_TOKEN_BEDROCK` repo secret — referenced by name only, nothing sensitive is committed.

## Before this works
1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
2. Add a **long-term** Bedrock API key as the `AWS_BEARER_TOKEN_BEDROCK` Actions secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)